### PR TITLE
Relative abundance and count tables uses datatables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     scales,
     ggplot2,
     rentrez,
-    BatchQC
+    BatchQC,
+    DT
 Collate:
     'pathoStat.R'
     'utils.R'

--- a/inst/shiny/PathoStat/ui.R
+++ b/inst/shiny/PathoStat/ui.R
@@ -41,8 +41,8 @@ shinyUI(navbarPage("PathoStat", id="PathoStat", fluid=TRUE,
                         ggvisOutput("TaxRelAbundancePlot")),
                     tabPanel("Heatmap", plotOutput("Heatmap", height="550px")),
                     tabPanel("Summary", verbatimTextOutput("TaxRAsummary")),
-                    tabPanel("Table", tableOutput("TaxRAtable")),
-                    tabPanel("Count Table", tableOutput("TaxCountTable"))
+                    tabPanel("Table", DT::dataTableOutput("TaxRAtable", width='95%')),
+                    tabPanel("Count Table", DT::dataTableOutput("TaxCountTable", width='95%'))
                 ), width=9
             )
         )


### PR DESCRIPTION
Improved display for relative abundance and count tables using the DT (datatables) package. Has an additional dependency (DT) so I didn't want to push this into master without first checking with everyone.

Really easy to use this on all the other tables (such as differential expression table). I use this all the time when making Rdocs.

Take a look at [DT here](https://rstudio.github.io/DT/)
