### PR TITLE
Allows differential exp plot to pick covariates

### DIFF
--- a/inst/shiny/PathoStat/ui.R
+++ b/inst/shiny/PathoStat/ui.R
@@ -11,8 +11,23 @@ minbatch <- function(batch1){
     return(min(unlist(lapply(1:length(batch3), 
         function(x) length(batch3[[x]])))))
 }
-
+findphyloseqData <- function() {
+  ids <- rownames(shinyInput$data)
+  taxmat <- findTaxonMat(ids, shinyInput$taxonLevels)
+  OTU <- otu_table(shinyInput$countdata, taxa_are_rows = TRUE)
+  TAX <- tax_table(taxmat)
+  physeq <- phyloseq(OTU, TAX)
+  sampledata = sample_data(data.frame(condition=as.factor(
+    shinyInput$condition), batch=as.factor(shinyInput$batch), 
+    row.names=sample_names(physeq), stringsAsFactors=FALSE))
+  random_tree = rtree(ntaxa(physeq), rooted=TRUE, tip.label=
+                        taxa_names(physeq))
+  physeq1 <- merge_phyloseq(physeq, sampledata, random_tree)
+  return(physeq1)
+}
 shinyInput <- getShinyInput()
+phyloseq1 <- findphyloseqData()
+covariates <- colnames(sample_data(phyloseq1))
 maxbatchElems <- minbatch(shinyInput$batch)
 maxcondElems <- minbatch(shinyInput$condition)
 defaultDisp <- 30
@@ -107,19 +122,21 @@ shinyUI(navbarPage("PathoStat", id="PathoStat", fluid=TRUE,
             sidebarPanel(
                 selectizeInput('taxlde', 'Taxonomy Level', choices = tax.name, 
                     selected='no rank'),
-                numericInput('ncSamples', 'No. of Sample(s) Per Condition', 
+                selectizeInput('primary', 'Primary Covariate', choices = covariates),
+                selectizeInput('secondary', 'Secondary Covariate', choices = covariates),
+                numericInput('npSamples', 'No. of Sample(s) Per Primary Covariate', 
                     if (maxcondElems>defaultDisp) defaultDisp 
                     else maxcondElems, min = 1, max = maxcondElems),
-                numericInput('noSamples', 'No. of Sample(s) Per Batch', 
+                numericInput('nsSamples', 'No. of Sample(s) Per Secondary Covariate', 
                     if (maxbatchElems>defaultDisp) defaultDisp 
                     else maxbatchElems, min = 1, max = maxbatchElems),
-                checkboxInput("sortbybatch", 
-                    "Sort By Batch First (Default: Sort By Condition First)", 
+                checkboxInput("sortbysecondary", 
+                    "Sort By Secondary Covariate First (Default: Sort By Primary Covariate First)", 
                     FALSE),
-                checkboxInput("colbybatch", 
-                    "Color By Batch (Default: Color By Condition)", FALSE),
+                checkboxInput("colbysecondary", 
+                    "Color By Secondary Covariate (Default: Color By Primary Covariate)", FALSE),
                 numericInput('noTaxons', 
-                    'No. of top Differentially Expressed Taxons to display', 
+                    'No. of top Differentially Expressed Taxa to display', 
                     if (maxGenes>defaultGenesDisp) defaultGenesDisp 
                     else maxGenes, min = 1, max = maxGenes),
                 width=3


### PR DESCRIPTION
These are the companion changes to the ones I made in server.R to the "differential expression" boxplot. Mostly, it allows the inputs to be from the phyloseq object instead of "batch" and "condition" vectors, and it allows users to select covariates of interest from a list. I added a copy of findPhyseqData() in order to populate the pull-down menu for covariates, but I don't expect that to be the final solution here.
