### PR TITLE
Git ignore packrat libraries and files

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^packrat/
+^\.Rprofile$

--- a/.gitignore
+++ b/.gitignore
@@ -4,20 +4,19 @@
 
 # Example code in package build process
 *-Ex.R
-
 # RStudio files
 .Rproj.user/
-
 # produced vignettes
 vignettes/*.html
 vignettes/*.pdf
 .Rproj.user
-
 *.Rproj
 inst/doc
 .RData
-.Rhistory
-
 # Miscellaneous
 tmp/
 .DS_Store
+packrat/lib*/
+packrat/src/
+packrat
+.Rprofile


### PR DESCRIPTION
Adds a few ignores so that packrat can be used (for development). Packrat helps to manage R package libraries so that software can be tested without interfering with system-wide R packages.

The reason for this is that I've been having issues building PathoStat and its dependencies, sometimes clobbering my system-wide installs. Packrat lets me test PathoStat as if I had a clean install.
